### PR TITLE
#refactoring  공통메타정보 추상클래스로 변경

### DIFF
--- a/src/main/java/com/amy/springboard/domain/AuditingMetaInfo.java
+++ b/src/main/java/com/amy/springboard/domain/AuditingMetaInfo.java
@@ -18,7 +18,7 @@ import java.time.LocalDateTime;
 @ToString
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
-public class AuditingMetaInfo {
+public abstract class AuditingMetaInfo {
 
     @CreatedDate
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)


### PR DESCRIPTION
공통메타정보를 위해 상속만을 위한 클래스이기 때문에 
추상클래스로 변경